### PR TITLE
Make installing dupterm_notify dependent on availability.

### DIFF
--- a/utelnet/utelnetserver.py
+++ b/utelnet/utelnetserver.py
@@ -75,7 +75,9 @@ def accept_telnet_connect(telnet_server):
     print("Telnet connection from:", remote_addr)
     last_client_socket.setblocking(False)
     # dupterm_notify() not available under MicroPython v1.1
-    # last_client_socket.setsockopt(socket.SOL_SOCKET, 20, uos.dupterm_notify)
+    # Set socket option only if present
+    if hasattr(uos, 'dupterm_notify'):
+        last_client_socket.setsockopt(socket.SOL_SOCKET, 20, uos.dupterm_notify)
     
     last_client_socket.sendall(bytes([255, 252, 34])) # dont allow line mode
     last_client_socket.sendall(bytes([255, 251, 1])) # turn off local echo


### PR DESCRIPTION
This makes utelnet work with Micropython 1.13 on ESP32.